### PR TITLE
Update BoarderControl.cs

### DIFF
--- a/Lec/Lec3Code/Sub02/BoarderControl.cs
+++ b/Lec/Lec3Code/Sub02/BoarderControl.cs
@@ -1,24 +1,67 @@
 using UnityEngine;
 
-public class BoarderControl : MonoBehaviour
+/// <summary>
+/// Controls the rotation of a 2D Rigidbody using torque.
+/// Designed for objects like snowboards, skateboards, etc.
+/// </summary>
+[RequireComponent(typeof(Rigidbody2D))] // Ensures a Rigidbody2D component is attached
+public class BoardController : MonoBehaviour
 {
-    [SerializeField] float torqueAmount = 10.0f;
-    Rigidbody2D rb2d;
-    // Start is called once before the first execution of Update after the MonoBehaviour is created
-    void Start()
+    [Tooltip("The magnitude of torque applied for rotation. " +
+             "NOTE: This value is a direct torque. You will likely need to adjust this value " +
+             "significantly (likely making it smaller) compared to the original script " +
+             "because Time.deltaTime scaling has been removed for physics correctness.")]
+    [SerializeField] float torqueAmount = 1.0f; // Example: Might need to be 0.1 or 0.5 instead of 10
+
+    private Rigidbody2D rb2d;
+    private float rotationInput; // Stores the input for rotation (-1 for right, 1 for left, 0 for none)
+
+    void Awake()
     {
+        // Cache the Rigidbody2D component for performance and reliability
         rb2d = GetComponent<Rigidbody2D>();
+
+        // Defensive check, though RequireComponent should prevent this
+        if (rb2d == null)
+        {
+            Debug.LogError("BoardController on " + gameObject.name + " requires a Rigidbody2D component, but it's missing.", this);
+            enabled = false; // Disable this script if the crucial component is not found
+        }
     }
 
-    // Update is called once per frame
     void Update()
     {
+        // Gather input in Update() for maximum responsiveness.
+        // This determines the desired direction of rotation.
+        rotationInput = 0f; // Reset input each frame
 
-        if (Input.GetKey(KeyCode.LeftArrow) ) {
-            rb2d.AddTorque(torqueAmount * Time.deltaTime);
+        if (Input.GetKey(KeyCode.LeftArrow))
+        {
+            rotationInput += 1f; // Positive for counter-clockwise torque (left rotation)
         }
-        if (Input.GetKey(KeyCode.RightArrow) ) {
-            rb2d.AddTorque(-torqueAmount * Time.deltaTime);
+        if (Input.GetKey(KeyCode.RightArrow))
+        {
+            rotationInput -= 1f; // Negative for clockwise torque (right rotation)
         }
+
+        // Alternative for smoother/analog input (e.g., joystick or Input Manager axis):
+        // rotationInput = Input.GetAxis("Horizontal"); // Adjust axis name and direction as needed
+        // If using Horizontal axis, typically right is positive, so you might want:
+        // rotationInput = -Input.GetAxis("Horizontal"); // To make left positive torque
+    }
+
+    void FixedUpdate()
+    {
+        // Apply physics-related changes in FixedUpdate() for consistency.
+        if (rb2d == null || rotationInput == 0f)
+        {
+            // Do nothing if Rigidbody is missing or there's no input
+            return;
+        }
+
+        // Apply torque. torqueAmount is the direct magnitude of the torque.
+        // rotationInput determines the direction (+1 or -1).
+        // The physics engine applies this torque over Time.fixedDeltaTime.
+        rb2d.AddTorque(rotationInput * torqueAmount);
     }
 }


### PR DESCRIPTION
How to Adjust torqueAmount (Very Important!):

Your original script was:
rb2d.AddTorque(torqueAmount * Time.deltaTime);

The new script is:
rb2d.AddTorque(rotationInput * torqueAmount); (where rotationInput is -1, 0, or 1)

In the original script, torqueAmount was scaled down by Time.deltaTime (e.g., roughly 0.0167 at 60 FPS, or 0.02 for default fixed timestep if it was in FixedUpdate). In the new script, torqueAmount is used directly as the torque magnitude. To get a similar initial feel to your old script:

Take your old torqueAmount value.
Multiply it by Time.fixedDeltaTime (Unity's default fixed timestep is usually 0.02 seconds). Example: If your old torqueAmount was 10.0f.
New approximate torqueAmount = 10.0f * 0.02f = 0.2f. Start with this new, smaller value (e.g., 0.2f) for torqueAmount in the Inspector and then fine-tune it until the rotation feels right. The new approach is more physically correct and will behave consistently regardless of frame rate fluctuations.

Further Potential Enhancements (Beyond This Upgrade):

Max Angular Velocity: You might want to clamp rb2d.angularVelocity to prevent the board from spinning too fast. Angular Damping: Adjust the Angular Drag property on the Rigidbody2D component itself in the Inspector to control how quickly the board stops spinning when no torque is applied. Input Abstraction: Use Unity's Input Manager (Edit > Project Settings > Input Manager) to define "Horizontal" axes, allowing users to remap controls and support gamepads more easily. State-Based Control: You might want different torque amounts or behaviors if the boarder is in the air versus on the ground. This upgraded script provides a more robust and physically sound foundation for your board control. Remember to adjust the torqueAmount in the Inspector!